### PR TITLE
Fix conditional guard for port display name test

### DIFF
--- a/tests/core/test_port.cpp
+++ b/tests/core/test_port.cpp
@@ -161,15 +161,11 @@ TEST_CASE("Port: Empty name", "[port][edge]") {
     REQUIRE(port.get_name().empty());
 }
 
-#if 0  // Display name feature not yet implemented
+#if defined(VISPROG_ENABLE_PORT_DISPLAY_NAME_TEST)
 TEST_CASE("Port: Display name", "[port]") {
     Port port(PortId{1}, PortDirection::Input, DataType::Int32, "value");
 
     REQUIRE(port.get_name() == "value");
 }
-#endif
-
-
-    REQUIRE(port.get_name() == "value");
-}
 #endif  // VISPROG_ENABLE_PORT_DISPLAY_NAME_TEST
+


### PR DESCRIPTION
## Summary
- fix the display name test guard to rely on VISPROG_ENABLE_PORT_DISPLAY_NAME_TEST
- remove stray duplicated lines so the test suite compiles cleanly again

## Testing
- not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917659eb8b08323b09eaf42ee72c380)