### PR TITLE
Fix port display name test formatting

### DIFF
--- a/tests/core/test_port.cpp
+++ b/tests/core/test_port.cpp
@@ -164,8 +164,6 @@ TEST_CASE("Port: Empty name", "[port][edge]") {
 #if defined(VISPROG_ENABLE_PORT_DISPLAY_NAME_TEST)
 TEST_CASE("Port: Display name", "[port]") {
     Port port(PortId{1}, PortDirection::Input, DataType::Int32, "value");
-
     REQUIRE(port.get_name() == "value");
 }
 #endif  // VISPROG_ENABLE_PORT_DISPLAY_NAME_TEST
-


### PR DESCRIPTION
## Summary
- remove extra blank lines inside the VISPROG_ENABLE_PORT_DISPLAY_NAME_TEST guard to match clang-format output

## Testing
- clang-format -i tests/core/test_port.cpp

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69176f90969c83239e8e3dc1f94bf8fb)